### PR TITLE
Add PWA manifest and refine font imports

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,8 @@ import svelte from "@astrojs/svelte";
 
 // https://astro.build/config
 export default defineConfig({
+  // The `site` property specifies the base URL for your site.
+  // Be sure to update this to your own domain (e.g., "https://yourdomain.com") before deploying.
   site: "https://data-nova.vercel.app",
   prefetch: true,
   trailingSlash: "never",

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,21 @@
+{
+  "short_name": "DataNova",
+  "name": "DataNova",
+  "icons": [
+    {
+      "src": "./icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "./icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "display": "minimal-ui",
+  "id": "/",
+  "start_url": "/",
+  "theme_color": "#fefefe",
+  "background_color": "#85c5c5"
+}

--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -1,5 +1,5 @@
-@import url("https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,100..1000&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Work+Sans:wght@100..900&display=swap");
 @import "tailwindcss";
 @import "preline/variants.css";
 @plugin '@tailwindcss/forms';

--- a/src/layout/BaseLayout.astro
+++ b/src/layout/BaseLayout.astro
@@ -68,6 +68,7 @@ const defaultSchema: WithContext<Thing> = {
         link: [
           { rel: "icon", href: "/icon.svg", type: "image/svg+xml" },
           { rel: "apple-touch-icon", href: "/apple-touch-icon.png" },
+          { rel: "manifest", href: "/manifest.webmanifest" },
         ],
         meta: [
           { name: "viewport", content: "width=device-width" },
@@ -87,7 +88,7 @@ const defaultSchema: WithContext<Thing> = {
         {
           src: [],
           name: "DM Sans",
-          googleFontsURL: "https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap",
+          googleFontsURL: "https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,100..1000&display=swap",
           preload: true,
           display: "swap",
           selector: "h1, h2, h3, h4",
@@ -96,7 +97,7 @@ const defaultSchema: WithContext<Thing> = {
         {
           src: [],
           name: "Work Sans",
-          googleFontsURL: "https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap",
+          googleFontsURL: "https://fonts.googleapis.com/css2?family=Work+Sans:wght@100..900&display=swap",
           preload: true,
           display: "swap",
           selector: "body",

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,10 +1,14 @@
 import type { APIRoute } from 'astro';
 
+// Helper function that generates the content for the robots.txt file
+// This specifies that all web crawlers (User-agent: *) have access to the entire site (Allow: /)
 const getRobotsTxt = () => `
 User-agent: *
 Allow: /
 `;
 
+// API route for serving the robots.txt file
+// When a GET request is made to this route, it returns the generated robots.txt content
 export const GET: APIRoute = () => {
   return new Response(getRobotsTxt());
 };


### PR DESCRIPTION
Introduced a web manifest file for enabling PWA capabilities, updated font import URLs for better optimization, and included the manifest link in the base layout. Also added explanatory comments in robots.txt and astro.config.mjs for improved maintainability.